### PR TITLE
Log4j fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,20 +144,10 @@ subprojects { project ->
             testCompile "org.mockito:mockito-core"
             testCompile "org.grails:grails-web-testing-support"
 
-            constraints {
-                implementation('org.apache.logging.log4j:log4j-core:2.17.1') {
-                    because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
-                }
-                implementation('org.apache.logging.log4j:log4j-api:2.17.1') {
-                    because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
-                }
-                implementation('ch.qos.logback:logback-classic:1.2.10') {
-                    because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
-                }
-                implementation('ch.qos.logback:logback-core:1.2.10') {
-                    because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
-                }
-            }
+            compile "org.apache.logging.log4j:log4j-to-slf4j:2.17.1"
+            compile "org.apache.logging.log4j:log4j-api:2.17.1"
+            compile "ch.qos.logback:logback-classic:1.2.10"
+            compile "ch.qos.logback:logback-core:1.2.10"
 
             if ( isGrailsApp )
             {

--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,21 @@ subprojects { project ->
             testCompile "org.mockito:mockito-core"
             testCompile "org.grails:grails-web-testing-support"
 
+            constraints {
+                implementation('org.apache.logging.log4j:log4j-core:2.17.1') {
+                    because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
+                }
+                implementation('org.apache.logging.log4j:log4j-api:2.17.1') {
+                    because 'Log4j vulnerable to remote code execution and other critical security vulnerabilities'
+                }
+                implementation('ch.qos.logback:logback-classic:1.2.10') {
+                    because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
+                }
+                implementation('ch.qos.logback:logback-core:1.2.10') {
+                    because 'Logback vulnerable to remote code execution and other critical security vulnerabilities'
+                }
+            }
+
             if ( isGrailsApp )
             {
                 compile "org.grails.plugins:events"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-buildVersion=2.1.0
+buildVersion=2.1.1
 
 grailsVersion=4.0.6
 gorm.version=7.0.8.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-buildVersion=2.2.0
+buildVersion=2.1.0
 
 grailsVersion=4.0.6
 gorm.version=7.0.8.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-buildVersion=2.1.0
+buildVersion=2.2.0
 
 grailsVersion=4.0.6
 gorm.version=7.0.8.RELEASE


### PR DESCRIPTION
Changed `build.gradle` to compile latest version of log4j and logback, version bumped from 2.1.0 to 2.1.1. 